### PR TITLE
chore: 升级 GitHub Actions 以兼容 Node.js 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,14 +12,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: hexo
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## 背景

GitHub Actions 的 deploy 工作流在运行时输出 warning：

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4, peaceiris/actions-gh-pages@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## 变更内容

| 项目 | 旧版本 | 新版本 | 说明 |
|------|--------|--------|------|
| actions/checkout | @v4 | @v6 | v6 基于 Node.js 24 运行时 |
| actions/setup-node | @v4 | @v6 | v6 基于 Node.js 24 运行时 |
| node-version | 18 | 22 | Node.js 18 已 EOL，22 为当前 Active LTS |
| peaceiris/actions-gh-pages | @v4 | @v4 | @v4 标签现已指向 v4.1.0，包含 Node.js 24 运行时更新 |

## 是否需要升级？有什么风险？

**需要升级。** 2026-06-02 起 GitHub Actions 将强制使用 Node.js 24，不升级的 action 可能无法正常运行。

**升级风险很低：**
- `actions/checkout` v6 向后兼容，API 无变化
- `actions/setup-node` v6 唯一的 breaking change 是自动缓存仅限 npm（当前工作流已使用 `cache: npm`，不受影响）
- `peaceiris/actions-gh-pages` v4.1.0 仅更新了 Node 运行时和依赖，功能无变化
- Node.js 22 是当前 Active LTS，Hexo 及其依赖完全兼容

## 关键时间节点

- **2026-06-02**：GitHub Actions 强制切换到 Node.js 24
- **2026-09-16**：Node.js 20 从 runner 中移除